### PR TITLE
Add EmitError::Unimplemented to report unimplemented error

### DIFF
--- a/rust/emitter/src/ast_emitter.rs
+++ b/rust/emitter/src/ast_emitter.rs
@@ -2,22 +2,25 @@
 //!
 //! Converts AST nodes to bytecode.
 
-use super::emitter::{EmitResult, Emitter};
+use super::emitter::{EmitResult, EmitError, Emitter};
 use super::opcode::Opcode;
 use ast::{arena, types::*};
 
 /// Emit a program, converting the AST directly to bytecode.
-pub fn emit_program(ast: &Program) -> EmitResult {
+pub fn emit_program(ast: &Program) -> Result<EmitResult, EmitError> {
     let mut emitter = AstEmitter {
         emit: Emitter::new(),
     };
 
     match ast {
-        Program::Script(script) => emitter.emit_script(script),
-        _ => unimplemented!(),
+        Program::Script(script) => emitter.emit_script(script)?,
+        _ => {
+            return Err(EmitError::Unimplemented(
+                "TODO: modules".to_string()));
+        }
     }
 
-    emitter.emit.into_emit_result()
+    Ok(emitter.emit.into_emit_result())
 }
 
 struct AstEmitter {
@@ -25,45 +28,111 @@ struct AstEmitter {
 }
 
 impl AstEmitter {
-    fn emit_script(&mut self, ast: &Script) {
+    fn emit_script(&mut self, ast: &Script) -> Result<(), EmitError> {
         for statement in &ast.statements {
-            self.emit_statement(statement);
+            self.emit_statement(statement)?;
         }
         self.emit.ret_rval();
+
+        Ok(())
     }
 
-    fn emit_statement(&mut self, ast: &Statement) {
+    fn emit_statement(&mut self, ast: &Statement) -> Result<(), EmitError> {
         match ast {
-            Statement::ClassDeclaration(_) => unimplemented!(),
-            Statement::BlockStatement { .. } => unimplemented!(),
-            Statement::BreakStatement { .. } => unimplemented!(),
-            Statement::ContinueStatement { .. } => unimplemented!(),
-            Statement::DebuggerStatement => unimplemented!(),
-            Statement::DoWhileStatement { .. } => unimplemented!(),
+            Statement::ClassDeclaration(_) => {
+                return Err(EmitError::Unimplemented(
+                    "TODO: ClassDeclaration".to_string()));
+            },
+            Statement::BlockStatement { .. } => {
+                return Err(EmitError::Unimplemented(
+                    "TODO: BlockStatement".to_string()));
+            },
+            Statement::BreakStatement { .. } => {
+                return Err(EmitError::Unimplemented(
+                    "TODO: BreakStatement".to_string()));
+            },
+            Statement::ContinueStatement { .. } => {
+                return Err(EmitError::Unimplemented(
+                    "TODO: ContinueStatement".to_string()));
+            },
+            Statement::DebuggerStatement => {
+                return Err(EmitError::Unimplemented(
+                    "TODO: DebuggerStatement".to_string()));
+            },
+            Statement::DoWhileStatement { .. } => {
+                return Err(EmitError::Unimplemented(
+                    "TODO: DoWhileStatement".to_string()));
+            },
             Statement::EmptyStatement => (),
             Statement::ExpressionStatement(ast) => {
-                self.emit_expression(ast);
+                self.emit_expression(ast)?;
                 self.emit.set_rval();
             }
-            Statement::ForInStatement { .. } => unimplemented!(),
-            Statement::ForOfStatement { .. } => unimplemented!(),
-            Statement::ForStatement { .. } => unimplemented!(),
-            Statement::IfStatement { .. } => unimplemented!(),
-            Statement::LabeledStatement { .. } => unimplemented!(),
-            Statement::ReturnStatement { expression } => self.emit_return_statement(expression),
-            Statement::SwitchStatement { .. } => unimplemented!(),
-            Statement::SwitchStatementWithDefault { .. } => unimplemented!(),
-            Statement::ThrowStatement { .. } => unimplemented!(),
-            Statement::TryCatchStatement { .. } => unimplemented!(),
-            Statement::TryFinallyStatement { .. } => unimplemented!(),
-            Statement::VariableDeclarationStatement(ast) => self.emit_variable_declaration(ast),
-            Statement::WhileStatement { .. } => unimplemented!(),
-            Statement::WithStatement { .. } => unimplemented!(),
-            Statement::FunctionDeclaration(_) => unimplemented!(),
-        }
+            Statement::ForInStatement { .. } => {
+                return Err(EmitError::Unimplemented(
+                    "TODO: ForInStatement".to_string()));
+            },
+            Statement::ForOfStatement { .. } => {
+                return Err(EmitError::Unimplemented(
+                    "TODO: ForOfStatement".to_string()));
+            },
+            Statement::ForStatement { .. } => {
+                return Err(EmitError::Unimplemented(
+                    "TODO: ForStatement".to_string()));
+            },
+            Statement::IfStatement { .. } => {
+                return Err(EmitError::Unimplemented(
+                    "TODO: IfStatement".to_string()));
+            },
+            Statement::LabeledStatement { .. } => {
+                return Err(EmitError::Unimplemented(
+                    "TODO: LabeledStatement".to_string()));
+            },
+            Statement::ReturnStatement { expression } => {
+                self.emit_return_statement(expression)?;
+            },
+            Statement::SwitchStatement { .. } => {
+                return Err(EmitError::Unimplemented(
+                    "TODO: SwitchStatement".to_string()));
+            },
+            Statement::SwitchStatementWithDefault { .. } => {
+                return Err(EmitError::Unimplemented(
+                    "TODO: SwitchStatementWithDefault".to_string()));
+            },
+            Statement::ThrowStatement { .. } => {
+                return Err(EmitError::Unimplemented(
+                    "TODO: ThrowStatement".to_string()));
+            },
+            Statement::TryCatchStatement { .. } => {
+                return Err(EmitError::Unimplemented(
+                    "TODO: TryCatchStatement".to_string()));
+            },
+            Statement::TryFinallyStatement { .. } => {
+                return Err(EmitError::Unimplemented(
+                    "TODO: TryFinallyStatement".to_string()));
+            },
+            Statement::VariableDeclarationStatement(ast) => {
+                self.emit_variable_declaration(ast)?
+            },
+            Statement::WhileStatement { .. } => {
+                return Err(EmitError::Unimplemented(
+                    "TODO: WhileStatement".to_string()));
+            },
+            Statement::WithStatement { .. } => {
+                return Err(EmitError::Unimplemented(
+                    "TODO: WithStatement".to_string()));
+            },
+            Statement::FunctionDeclaration(_) => {
+                return Err(EmitError::Unimplemented(
+                    "TODO: FunctionDeclaration".to_string()));
+            },
+        };
+
+        Ok(())
     }
 
-    fn emit_variable_declaration(&mut self, ast: &VariableDeclaration) {
+    fn emit_variable_declaration(&mut self, ast: &VariableDeclaration)
+                                 -> Result<(), EmitError> {
         match ast.kind {
             VariableDeclarationKind::Var => (),
             VariableDeclarationKind::Let => (),
@@ -71,7 +140,10 @@ impl AstEmitter {
         }
         for declarator in &ast.declarators {
             let _ = match &declarator.binding {
-                Binding::BindingPattern(_) => unimplemented!(),
+                Binding::BindingPattern(_) => {
+                    return Err(EmitError::Unimplemented(
+                        "TODO: BindingPattern".to_string()));
+                },
                 Binding::BindingIdentifier(ident) => &ident.name.value,
             };
             // TODO
@@ -80,28 +152,34 @@ impl AstEmitter {
             self.emit.pop();
 
             if let Some(init) = &declarator.init {
-                self.emit_expression(&*init);
+                self.emit_expression(&*init)?;
             }
 
             self.emit.init_lexical(0);
             self.emit.pop();
         }
+
+        Ok(())
     }
 
-    fn emit_return_statement(&mut self, expression: &Option<arena::Box<Expression>>) {
+    fn emit_return_statement(&mut self, expression: &Option<arena::Box<Expression>>)
+                             -> Result<(), EmitError> {
         match expression {
-            Some(ast) => self.emit_expression(ast),
+            Some(ast) => self.emit_expression(ast)?,
             None => self.emit.undefined(),
         }
         self.emit.set_rval();
         self.emit.ret_rval();
+
+        Ok(())
     }
 
-    fn emit_this(&mut self) {
-        unimplemented!();
+    fn emit_this(&mut self) -> Result<(), EmitError> {
+        Err(EmitError::Unimplemented(
+            "TODO: this".to_string()))
     }
 
-    fn emit_expression(&mut self, ast: &Expression) {
+    fn emit_expression(&mut self, ast: &Expression) -> Result<(), EmitError> {
         match ast {
             Expression::MemberExpression(MemberExpression::ComputedMemberExpression(
                 ComputedMemberExpression {
@@ -109,8 +187,8 @@ impl AstEmitter {
                     expression,
                 },
             )) => {
-                self.emit_expression(object);
-                self.emit_expression(expression);
+                self.emit_expression(object)?;
+                self.emit_expression(expression)?;
                 self.emit.get_elem();
             }
 
@@ -120,8 +198,8 @@ impl AstEmitter {
                     expression,
                 },
             )) => {
-                self.emit_this();
-                self.emit_expression(expression);
+                self.emit_this()?;
+                self.emit_expression(expression)?;
                 self.emit.callee();
                 self.emit.super_base();
                 self.emit.get_elem_super();
@@ -133,7 +211,7 @@ impl AstEmitter {
                     property,
                 },
             )) => {
-                self.emit_expression(object);
+                self.emit_expression(object)?;
                 self.emit.get_prop(&property.value);
             }
 
@@ -143,13 +221,16 @@ impl AstEmitter {
                     property,
                 },
             )) => {
-                self.emit_this();
+                self.emit_this()?;
                 self.emit.callee();
                 self.emit.super_base();
                 self.emit.get_prop_super(&property.value);
             }
 
-            Expression::ClassExpression(_) => unimplemented!(),
+            Expression::ClassExpression(_) => {
+                return Err(EmitError::Unimplemented(
+                    "TODO: ClassExpressionr".to_string()));
+            },
 
             Expression::LiteralBooleanExpression(literal) => {
                 self.emit.emit_boolean(literal.value);
@@ -167,33 +248,63 @@ impl AstEmitter {
                 self.emit_numeric_expression(ast);
             }
 
-            Expression::LiteralRegExpExpression(_) => unimplemented!(),
+            Expression::LiteralRegExpExpression(_) => {
+                return Err(EmitError::Unimplemented(
+                    "TODO: LiteralRegExpExpression".to_string()));
+            },
 
             Expression::LiteralStringExpression(ast) => {
                 self.emit.string(&ast.value);
             }
 
-            Expression::ArrayExpression(_) => unimplemented!(),
-            Expression::ArrowExpression(_) => unimplemented!(),
-            Expression::AssignmentExpression(_) => unimplemented!(),
+            Expression::ArrayExpression(_) => {
+                return Err(EmitError::Unimplemented(
+                    "TODO: ArrayExpression".to_string()));
+            },
+            Expression::ArrowExpression(_) => {
+                return Err(EmitError::Unimplemented(
+                    "TODO: ArrowExpression".to_string()));
+            },
+            Expression::AssignmentExpression(_) => {
+                return Err(EmitError::Unimplemented(
+                    "TODO: AssignmentExpression".to_string()));
+            },
             Expression::BinaryExpression(ast) => {
-                self.emit_binary_expression(ast);
+                self.emit_binary_expression(ast)?;
             }
 
             Expression::CallExpression(ast) => {
-                self.emit_call_expression(ast);
+                self.emit_call_expression(ast)?;
             }
 
-            Expression::CompoundAssignmentExpression(_) => unimplemented!(),
-            Expression::ConditionalExpression(_) => unimplemented!(),
-            Expression::FunctionExpression(_) => unimplemented!(),
+            Expression::CompoundAssignmentExpression(_) => {
+                return Err(EmitError::Unimplemented(
+                    "TODO: CompoundAssignmentExpression".to_string()));
+            },
+            Expression::ConditionalExpression(_) => {
+                return Err(EmitError::Unimplemented(
+                    "TODO: ConditionalExpression".to_string()));
+            },
+            Expression::FunctionExpression(_) => {
+                return Err(EmitError::Unimplemented(
+                    "TODO: FunctionExpression".to_string()));
+            },
             Expression::IdentifierExpression(ast) => {
                 self.emit_identifier_expression(ast);
             }
 
-            Expression::NewExpression(_) => unimplemented!(),
-            Expression::NewTargetExpression => unimplemented!(),
-            Expression::ObjectExpression(_) => unimplemented!(),
+            Expression::NewExpression(_) => {
+                return Err(EmitError::Unimplemented(
+                    "TODO: NewExpression".to_string()));
+            },
+            Expression::NewTargetExpression => {
+                return Err(EmitError::Unimplemented(
+                    "TODO: NewTargetExpression".to_string()));
+            },
+            Expression::ObjectExpression(_) => {
+                return Err(EmitError::Unimplemented(
+                    "TODO: ObjectExpression".to_string()));
+            },
 
             Expression::UnaryExpression(UnaryExpression { operator, operand }) => {
                 let opcode = match operator {
@@ -202,29 +313,56 @@ impl AstEmitter {
                     UnaryOperator::LogicalNot => Opcode::Not,
                     UnaryOperator::BitwiseNot => Opcode::BitNot,
                     UnaryOperator::Void => Opcode::Void,
-                    UnaryOperator::Typeof => unimplemented!(),
-                    UnaryOperator::Delete => unimplemented!(),
+                    UnaryOperator::Typeof => {
+                        return Err(EmitError::Unimplemented(
+                            "TODO: Typeof".to_string()));
+                    },
+                    UnaryOperator::Delete => {
+                        return Err(EmitError::Unimplemented(
+                            "TODO: Delete".to_string()));
+                    },
                 };
-                self.emit_expression(operand);
+                self.emit_expression(operand)?;
                 self.emit.emit_unary_op(opcode);
             }
 
-            Expression::TemplateExpression(_) => unimplemented!(),
+            Expression::TemplateExpression(_) => {
+                return Err(EmitError::Unimplemented(
+                    "TODO: TemplateExpression".to_string()));
+            },
 
             Expression::ThisExpression => {
-                self.emit_this();
+                self.emit_this()?;
             }
 
-            Expression::UpdateExpression(_) => unimplemented!(),
-            Expression::YieldExpression(_) => unimplemented!(),
-            Expression::YieldGeneratorExpression(_) => unimplemented!(),
-            Expression::AwaitExpression(_) => unimplemented!(),
-            Expression::ImportCallExpression(_) => unimplemented!(),
+            Expression::UpdateExpression(_) => {
+                return Err(EmitError::Unimplemented(
+                    "TODO: UpdateExpression".to_string()));
+            },
+            Expression::YieldExpression(_) => {
+                return Err(EmitError::Unimplemented(
+                    "TODO: YieldExpression".to_string()));
+            },
+            Expression::YieldGeneratorExpression(_) => {
+                return Err(EmitError::Unimplemented(
+                    "TODO: YieldGeneratorExpression".to_string()));
+            },
+            Expression::AwaitExpression(_) => {
+                return Err(EmitError::Unimplemented(
+                    "TODO: AwaitExpression".to_string()));
+            },
+            Expression::ImportCallExpression(_) => {
+                return Err(EmitError::Unimplemented(
+                    "TODO: ImportCallExpression".to_string()));
+            },
         }
+
+        Ok(())
     }
 
-    fn emit_binary_expression(&mut self, ast: &BinaryExpression) {
-        self.emit_expression(&*ast.left);
+    fn emit_binary_expression(&mut self, ast: &BinaryExpression)
+                              -> Result<(), EmitError> {
+        self.emit_expression(&*ast.left)?;
         let opcode = match ast.operator {
             BinaryOperator::Equals => Opcode::Eq,
             BinaryOperator::NotEquals => Opcode::Ne,
@@ -248,17 +386,28 @@ impl AstEmitter {
             BinaryOperator::BitwiseOr => Opcode::BitOr,
             BinaryOperator::BitwiseXor => Opcode::BitXor,
             BinaryOperator::BitwiseAnd => Opcode::BitAnd,
-            BinaryOperator::Coalesce => unimplemented!(),
-            BinaryOperator::LogicalOr => unimplemented!(),
-            BinaryOperator::LogicalAnd => unimplemented!(),
+            BinaryOperator::Coalesce => {
+                return Err(EmitError::Unimplemented(
+                    "TODO: Coalescer".to_string()));
+            }
+            BinaryOperator::LogicalOr => {
+                return Err(EmitError::Unimplemented(
+                    "TODO: LogicalOr".to_string()));
+            },
+            BinaryOperator::LogicalAnd => {
+                return Err(EmitError::Unimplemented(
+                    "TODO: LogicalAndr".to_string()));
+            },
             BinaryOperator::Comma => {
                 self.emit.pop();
-                self.emit_expression(&*ast.right);
-                return;
+                self.emit_expression(&*ast.right)?;
+                return Ok(());
             }
         };
-        self.emit_expression(&*ast.right);
+        self.emit_expression(&*ast.right)?;
         self.emit.emit_binary_op(opcode);
+
+        Ok(())
     }
 
     // We only want to emit integer values if the f64 value is *exactly* equivalent to a integer,
@@ -282,30 +431,43 @@ impl AstEmitter {
         self.emit.get_gname(name);
     }
 
-    fn emit_call_expression(&mut self, ast: &CallExpression) {
+    fn emit_call_expression(&mut self, ast: &CallExpression)
+                            -> Result<(), EmitError> {
         // Don't do super handling in an emit_expresion_or_super because the bytecode heavily
         // depends on how you're using the super
         match &ast.callee {
-            ExpressionOrSuper::Expression(ast) => self.emit_expression(ast),
-            ExpressionOrSuper::Super => unimplemented!(),
+            ExpressionOrSuper::Expression(ast) => self.emit_expression(ast)?,
+            ExpressionOrSuper::Super => {
+                return Err(EmitError::Unimplemented(
+                    "TODO: Super".to_string()));
+            }
         }
 
         self.emit.g_implicit_this("asdf");
 
-        self.emit_arguments(&ast.arguments);
+        self.emit_arguments(&ast.arguments)?;
         self.emit.call(ast.arguments.args.len() as u16);
+
+        Ok(())
     }
 
-    fn emit_arguments(&mut self, ast: &Arguments) {
+    fn emit_arguments(&mut self, ast: &Arguments) -> Result<(), EmitError> {
         for argument in &ast.args {
-            self.emit_argument(argument);
+            self.emit_argument(argument)?;
         }
+
+        Ok(())
     }
 
-    fn emit_argument(&mut self, ast: &Argument) {
+    fn emit_argument(&mut self, ast: &Argument) -> Result<(), EmitError> {
         match ast {
-            Argument::Expression(ast) => self.emit_expression(ast),
-            Argument::SpreadElement(_) => unimplemented!(),
+            Argument::Expression(ast) => self.emit_expression(ast)?,
+            Argument::SpreadElement(_) => {
+                return Err(EmitError::Unimplemented(
+                    "TODO: SpreadElement".to_string()));
+            }
         }
+
+        Ok(())
     }
 }

--- a/rust/emitter/src/emitter.rs
+++ b/rust/emitter/src/emitter.rs
@@ -35,6 +35,11 @@ pub struct EmitResult {
     pub strings: Vec<String>,
 }
 
+/// The error of bytecode-compilation.
+pub enum EmitError {
+    Unimplemented(String),
+}
+
 impl Emitter {
     pub fn new() -> Self {
         Self {
@@ -365,8 +370,9 @@ impl Emitter {
         self.emit_with_offset(Opcode::And, offset);
     }
 
-    pub fn table_switch(&mut self, _len: i32, _low: i32, _high: i32, _first_resume_index: u24) {
-        unimplemented!();
+    pub fn table_switch(&mut self, _len: i32, _low: i32, _high: i32, _first_resume_index: u24)
+                        -> Result<(), EmitError> {
+        Err(EmitError::Unimplemented("TODO: table_switch".to_string()))
     }
 
     pub fn strict_eq(&mut self) {

--- a/rust/emitter/src/lib.rs
+++ b/rust/emitter/src/lib.rs
@@ -4,10 +4,10 @@ mod emitter;
 mod lower;
 mod opcode;
 
-pub use crate::emitter::EmitResult;
+pub use crate::emitter::{EmitResult, EmitError};
 pub use dis::dis;
 
-pub fn emit(ast: &mut ast::types::Program) -> EmitResult {
+pub fn emit(ast: &mut ast::types::Program) -> Result<EmitResult, EmitError> {
     //lower::run(ast);
     ast_emitter::emit_program(ast)
 }
@@ -24,7 +24,9 @@ mod tests {
         let alloc = &Bump::new();
         let parse_result = parse_script(alloc, source).expect("Failed to parse");
         // println!("{:?}", parse_result);
-        let bc = emit(&mut ast::types::Program::Script(parse_result.unbox())).bytecode;
+        let bc = emit(&mut ast::types::Program::Script(parse_result.unbox()))
+            .expect("Should work!")
+            .bytecode;
         println!("{}", dis(&bc));
         bc
     }


### PR DESCRIPTION
Changed fallible emitter functions to return `Result<EmitResult, EmitError>` or `Result<(), EmitError>`,
and replaced `unimplemented!()` with `return Err(EmitError::Unimplemented("...".to_string()));`

Corresponding change to rust-frontend will use the result to report unimplemented error to the API consumer.
